### PR TITLE
[GAG-10610] Amplify Rails upgrade - additional tasks 2

### DIFF
--- a/lib/yammer/version.rb
+++ b/lib/yammer/version.rb
@@ -16,8 +16,8 @@ module Yammer
   class Version
     MAJOR = 2 unless defined? Yammer::MAJOR
     MINOR = 5 unless defined? Yammer::MINOR
-    PATCH = 0 unless defined? Yammer::PATCH
-    PRE = nil unless defined? Yammer::PRE
+    PATCH = 1 unless defined? Yammer::PATCH
+    PRE = 'rc1' unless defined? Yammer::PRE
 
     class << self
 

--- a/yam.gemspec
+++ b/yam.gemspec
@@ -40,8 +40,8 @@ Gem::Specification.new do |s|
   s.licenses         = ['MIT']
   s.test_files       = Dir.glob("spec/**/*")
 
-  s.cert_chain       = ['certs/public.pem']
-  s.signing_key      = File.expand_path("~/.gem/certs/private_key.pem") if $0 =~ /gem\z/
+  # s.cert_chain       = ['certs/public.pem']
+  # s.signing_key      = File.expand_path("~/.gem/certs/private_key.pem") if $0 =~ /gem\z/
 
   s.add_dependency 'oj', '~> 3.16'
   s.add_dependency 'multi_json', '~> 1.8'

--- a/yam.gemspec
+++ b/yam.gemspec
@@ -43,9 +43,9 @@ Gem::Specification.new do |s|
   s.cert_chain       = ['certs/public.pem']
   s.signing_key      = File.expand_path("~/.gem/certs/private_key.pem") if $0 =~ /gem\z/
 
-  s.add_dependency 'oj', '~> 2.14'
+  s.add_dependency 'oj', '~> 3.16'
   s.add_dependency 'multi_json', '~> 1.8'
-  s.add_dependency 'rest-client', '~> 1.8'
+  s.add_dependency 'rest-client', '~> 2.1'
   s.add_dependency 'addressable', '~> 2.4'
   s.add_dependency 'oauth2-client', '~> 2.0'
 


### PR DESCRIPTION
References: [GAG-10610], [GAG-9488]

This PR update gem dependencies to ensure compatibility with Rails 6 and Ruby 3

[GAG-10610]: https://gaggleamp.atlassian.net/browse/GAG-10610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GAG-9488]: https://gaggleamp.atlassian.net/browse/GAG-9488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ